### PR TITLE
fix: guard Firebase initialization against missing credentials at build time

### DIFF
--- a/src/app/api/admin/login/route.ts
+++ b/src/app/api/admin/login/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { signInWithEmailAndPassword } from 'firebase/auth';
 import { auth } from '@/lib/firebase';
 
+export const dynamic = 'force-dynamic';
+
 export async function POST(request: NextRequest) {
   try {
     const { email, password, rememberMe } = await request.json();

--- a/src/app/api/gallery/route.ts
+++ b/src/app/api/gallery/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/firebase';
 import { collection, getDocs, query, orderBy, limit, startAfter, doc, getDoc } from 'firebase/firestore';
 
+export const dynamic = 'force-dynamic';
+
 // GET - Fetch gallery images for public display
 export async function GET(request: NextRequest) {
   try {

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,7 +1,7 @@
-import { initializeApp, getApps } from 'firebase/app';
-import { getAuth } from 'firebase/auth';
-import { getFirestore } from 'firebase/firestore';
-import { getStorage } from 'firebase/storage';
+import { initializeApp, getApps, type FirebaseApp } from 'firebase/app';
+import { getAuth, type Auth } from 'firebase/auth';
+import { getFirestore, type Firestore } from 'firebase/firestore';
+import { getStorage, type FirebaseStorage } from 'firebase/storage';
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -12,12 +12,17 @@ const firebaseConfig = {
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
 };
 
-// Initialize Firebase
-const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
+// Guard against build-time initialization without credentials.
+// In production (Vercel) the NEXT_PUBLIC_FIREBASE_API_KEY env var is always set.
+// During CI builds or local dev without .env, we skip initialization to avoid
+// the auth/invalid-api-key error when Next.js statically analyzes server routes.
+let app: FirebaseApp | null = null;
+if (process.env.NEXT_PUBLIC_FIREBASE_API_KEY) {
+  app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
+}
 
-// Initialize Firebase services
-export const auth = getAuth(app);
-export const db = getFirestore(app);
-export const storage = getStorage(app);
+export const auth: Auth = app ? getAuth(app) : (null as unknown as Auth);
+export const db: Firestore = app ? getFirestore(app) : (null as unknown as Firestore);
+export const storage: FirebaseStorage = app ? getStorage(app) : (null as unknown as FirebaseStorage);
 
 export default app;


### PR DESCRIPTION
## Summary

- Skip Firebase initialization when `NEXT_PUBLIC_FIREBASE_API_KEY` is not set, preventing `auth/invalid-api-key` errors during `next build` in CI
- Add `export const dynamic = 'force-dynamic'` to API routes that use Firebase to prevent Next.js static analysis from triggering Firebase at build time
- In production (Vercel), env vars are always set so behavior is unchanged

## Why

CI was failing with `FirebaseError: auth/invalid-api-key` during `next build` because `firebase.ts` initializes Firebase eagerly at module import time. When the API key secret is not available in the build environment, this throws immediately.

## Test plan
- [ ] CI build passes without Firebase credentials in environment
- [ ] Admin login still works in production (Vercel has env vars set)
- [ ] Gallery API still works in production